### PR TITLE
feat/BE-678/add transport error as acceptable error

### DIFF
--- a/src/Kafka/Callback/KafkaErrorCallback.php
+++ b/src/Kafka/Callback/KafkaErrorCallback.php
@@ -18,6 +18,10 @@ final class KafkaErrorCallback
      */
     public function __invoke($kafka, int $errorCode, string $reason)
     {
+        if (RD_KAFKA_RESP_ERR__TRANSPORT === $errorCode) {
+            return;
+        }
+
         throw new KafkaBrokerException(
             $reason,
             $errorCode


### PR DESCRIPTION
https://github.com/edenhill/librdkafka/issues/64#issuecomment-33316652

a node from the cluster should be able to go away, without us failing

as far as i understand librdkafka updates and connects automatically again in this case, the debug output suggests the same:
```
%7|1521031704.069|TOPPAR|rdkafka#producer-1| [thrd:ssl://54.171.241.77:24868/1]: ssl://54.171.241.77:24868/1: company [0] 0+0 msgs
%7|1521031704.069|METADATA|rdkafka#producer-1| [thrd:main]: ssl://54.171.241.77:24868/1: ===== Received metadata (for 1 requested topics): broker down =====
%7|1521031704.069|METADATA|rdkafka#producer-1| [thrd:main]: ssl://54.171.241.77:24868/1: ClusterId: ELLPsyknQ6e9nh5DJG23Rw, ControllerId: 1
%7|1521031704.069|METADATA|rdkafka#producer-1| [thrd:main]: ssl://54.171.241.77:24868/1: 3 brokers, 1 topics
%7|1521031704.069|METADATA|rdkafka#producer-1| [thrd:main]: ssl://54.171.241.77:24868/1:   Broker #0/3: 34.244.98.79:24868 NodeId 2
%7|1521031704.069|METADATA|rdkafka#producer-1| [thrd:main]: ssl://54.171.241.77:24868/1:   Broker #1/3: 54.171.241.77:24868 NodeId 1
%7|1521031704.069|METADATA|rdkafka#producer-1| [thrd:main]: ssl://54.171.241.77:24868/1:   Broker #2/3: 34.240.204.9:24868 NodeId 0
%7|1521031704.070|METADATA|rdkafka#producer-1| [thrd:main]: ssl://54.171.241.77:24868/1:   Topic #0/1: company with 8 partitions
%7|1521031704.070|METADATA|rdkafka#producer-1| [thrd:main]:   Topic company partition 2 Leader 1
%7|1521031704.070|METADATA|rdkafka#producer-1| [thrd:main]:   Topic company partition 5 Leader 1
%7|1521031704.070|METADATA|rdkafka#producer-1| [thrd:main]:   Topic company partition 4 Leader 2
%7|1521031704.070|METADATA|rdkafka#producer-1| [thrd:main]:   Topic company partition 7 Leader 2
%7|1521031704.070|METADATA|rdkafka#producer-1| [thrd:main]:   Topic company partition 1 Leader 1
%7|1521031704.070|METADATA|rdkafka#producer-1| [thrd:main]:   Topic company partition 3 Leader 2
%7|1521031704.070|METADATA|rdkafka#producer-1| [thrd:main]:   Topic company partition 6 Leader 1
%7|1521031704.070|METADATA|rdkafka#producer-1| [thrd:main]:   Topic company partition 0 Leader 1
%7|1521031704.070|METADATA|rdkafka#producer-1| [thrd:main]: ssl://54.171.241.77:24868/1: 1/1 requested topic(s) seen in metadata
%7|1521031704.122|CONNECT|rdkafka#producer-1| [thrd:ssl://34.240.204.9:24868/0]: ssl://34.240.204.9:24868/0: broker in state DOWN connecting
%7|1521031704.122|CONNECT|rdkafka#producer-1| [thrd:ssl://34.240.204.9:24868/0]: ssl://34.240.204.9:24868/0: Connecting to ipv4#34.240.204.9:24868 (ssl) with socket 21
%7|1521031704.123|STATE|rdkafka#producer-1| [thrd:ssl://34.240.204.9:24868/0]: ssl://34.240.204.9:24868/0: Broker changed state DOWN -> CONNECT
%7|1521031704.123|BROADCAST|rdkafka#producer-1| [thrd:ssl://34.240.204.9:24868/0]: Broadcasting state change
```